### PR TITLE
could be prettier, but retain options

### DIFF
--- a/lib/formtastic_datepicker_inputs.rb
+++ b/lib/formtastic_datepicker_inputs.rb
@@ -8,23 +8,28 @@
 #format = options[:format] || Date::DATE_FORMATS[:default] || ‘%d %b %Y’
 module Formtastic
   if defined?(ActiveSupport::CoreExtensions)
-	DATE_FORMATS = ActiveSupport::CoreExtensions::Date::Conversions::DATE_FORMATS
+    DATE_FORMATS = ActiveSupport::CoreExtensions::Date::Conversions::DATE_FORMATS
   else
-	DATE_FORMATS = Date::DATE_FORMATS
+    DATE_FORMATS = Date::DATE_FORMATS
   end
  
   module DatePicker
     protected
 
     def date_picker_input(method, options = {})
-      format = options[:format] || DATE_FORMATS[:default] || '%d %b %Y'
-      string_input(method, date_picker_options(format, object.send(method)).merge(options))
+      options[:format] ||= DATE_FORMATS[:default] || '%d %b %Y'
+      string_input(method, options.merge(date_picker_options(options, object.send(method))))
     end
 
     # Generate html input options for the datepicker_input
     #
-    def date_picker_options(format, value = nil)
-      {:input_html => {:class => 'ui-date-picker',:value => value.try(:strftime, format)}}
+    def date_picker_options(options, value = nil)
+      options[:input_html] ||= {}
+      options[:input_html] = options[:input_html].reverse_merge!({
+        :class => (options[:input_html][:class]) ? "ui-date-picker #{options[:input_html][:class]}" : 'ui-date-picker',
+        :value => value.try(:strftime, options[:format])
+      })
+      options
     end
   end
   
@@ -33,13 +38,22 @@ module Formtastic
 
     def datetime_picker_input(method, options = {})
       format = options[:format] || DATE_FORMATS[:default] || '%d %b %Y %H:%M'
-      string_input(method, datetime_picker_options(format, object.send(method)).merge(options))
+      string_input(method, options.merge(datetime_picker_options(options, object.send(method))))
     end
 
     # Generate html input options for the datepicker_input
     #
-    def datetime_picker_options(format, value = nil)
-	  {:wrapper_html => {:class => 'datetime'},:input_html => {:class => 'ui-datetime-picker',:value => value.try(:strftime, format)}}
+    def datetime_picker_options(options, value = nil)
+      options[:wrapper_html] ||= {}
+      options[:wrapper_html] = options[:wrapper_html].reverse_merge!({
+        :class => (options[:wrapper_html][:class]) ? "datetime #{options[:input_html][:class]}" : 'datetime'
+      })
+      options[:input_html] ||= {}
+      options[:input_html] = options[:input_html].reverse_merge!({
+        :class =>  (options[:input_html][:class]) ? "ui-date-picker #{options[:input_html][:class]}" : 'ui-date-picker',
+        :value => value.try(:strftime, options[:format])
+      })
+      options
     end
   end
 end


### PR DESCRIPTION
fixes for:

 = form.input :start_at, :as => :date_picker, :input_html => {:class => "unicorns"}
